### PR TITLE
Add local WebSocket server for Tauri app

### DIFF
--- a/blendmate-app/docs/ARCHITECTURE.md
+++ b/blendmate-app/docs/ARCHITECTURE.md
@@ -1,0 +1,10 @@
+# Architecture Overview
+
+## Local WebSocket Server
+
+The Tauri backend hosts a Tokio-based WebSocket server listening on `127.0.0.1:32123`. Connections are accepted with `tokio-tungstenite`, and lifecycle events are surfaced to the frontend via Tauri events:
+
+- `ws:status`: Emitted with `"connected"` when a client handshake succeeds and `"disconnected"` when the connection ends.
+- `ws:message`: Emitted for each incoming text message, forwarding the raw payload.
+
+The server is started during app setup in `src-tauri/src/lib.rs` and runs entirely locally; no external networking is exposed.

--- a/blendmate-app/src-tauri/Cargo.toml
+++ b/blendmate-app/src-tauri/Cargo.toml
@@ -22,4 +22,7 @@ tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "sync", "time"] }
+tokio-tungstenite = "0.21"
+futures-util = "0.3"
 

--- a/blendmate-app/src-tauri/src/lib.rs
+++ b/blendmate-app/src-tauri/src/lib.rs
@@ -1,13 +1,74 @@
+use futures_util::StreamExt;
+use tokio::net::TcpListener;
+use tokio_tungstenite::{accept_async, tungstenite::Message};
+
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
 #[tauri::command]
 fn greet(name: &str) -> String {
     format!("Hello, {}! You've been greeted from Rust!", name)
 }
 
+const WS_ADDRESS: &str = "127.0.0.1:32123";
+
+fn start_websocket_server(app_handle: tauri::AppHandle) {
+    tauri::async_runtime::spawn(async move {
+        let listener = match TcpListener::bind(WS_ADDRESS).await {
+            Ok(listener) => listener,
+            Err(err) => {
+                eprintln!("Failed to bind WebSocket listener on {WS_ADDRESS}: {err}");
+                return;
+            }
+        };
+
+        loop {
+            let (stream, _) = match listener.accept().await {
+                Ok(connection) => connection,
+                Err(err) => {
+                    eprintln!("WebSocket accept error: {err}");
+                    continue;
+                }
+            };
+
+            let app_handle = app_handle.clone();
+
+            tauri::async_runtime::spawn(async move {
+                match accept_async(stream).await {
+                    Ok(mut websocket) => {
+                        let _ = app_handle.emit_all("ws:status", "connected");
+
+                        while let Some(message_result) = websocket.next().await {
+                            match message_result {
+                                Ok(Message::Text(text)) => {
+                                    let _ = app_handle.emit_all("ws:message", text);
+                                }
+                                Ok(Message::Close(_)) => break,
+                                Ok(_) => {}
+                                Err(err) => {
+                                    eprintln!("WebSocket read error: {err}");
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        eprintln!("WebSocket handshake error: {err}");
+                    }
+                }
+
+                let _ = app_handle.emit_all("ws:status", "disconnected");
+            });
+        }
+    });
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
+        .setup(|app| {
+            start_websocket_server(app.handle());
+            Ok(())
+        })
         .invoke_handler(tauri::generate_handler![greet])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");


### PR DESCRIPTION
## Summary
- run a tokio/tokio-tungstenite WebSocket server on 127.0.0.1:32123 inside the Tauri backend
- emit `ws:status` events on connection lifecycle changes and forward incoming text through `ws:message`
- document the local WebSocket flow in docs/ARCHITECTURE.md

## Testing
- cargo fmt --manifest-path src-tauri/Cargo.toml
- cargo check --manifest-path src-tauri/Cargo.toml *(fails: cannot reach crates.io index due to 403 CONNECT tunnel)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693fc1876cf0832bb341ee5aeeeb6514)