### PR TITLE
Add Blender 4.5 protocol event catalog

### DIFF
--- a/docs/PROTOCOL_EVENTS.md
+++ b/docs/PROTOCOL_EVENTS.md
@@ -1,0 +1,13 @@
+# Protocol Events Catalog (v0.1)
+
+This catalog targets Blender 4.5 and is generated from publicly available handlers in the Python API (e.g., `bpy.app.handlers.*`, `bpy.app.timers`, and `bpy.msgbus`). It is intentionally minimal so the Blendmate app can serialize events consistently.
+
+## Extending for future Blender versions
+
+1. **Clone the matching Blender tag** (e.g., `v4.6.x`) and skim the `release/scripts/modules/bpy/app/handlers.py` and `source/blender/makesrna` RNA updates for new handlers or properties.
+2. **Check API docs** at https://docs.blender.org/api/current/ for new or deprecated handlers (`bpy.app.handlers`, `bpy.msgbus`) and updated payload fields.
+3. **Add new events** by creating structured entries in `docs/protocol-events-v0.x.json` with `name`, `description`, `origin`, and `payload_schema_example`. Prefer additive changes; avoid renaming existing payload keys.
+4. **Version the catalog**: bump the filename suffix (e.g., `protocol-events-v0.2.json`) and keep prior files for backward compatibility.
+5. **Document migrations**: note handler changes and payload deltas in this file so clients know how to transition between versions.
+
+Following these steps keeps the event contract aligned with Blender releases while preserving compatibility for Blendmate clients.

--- a/docs/protocol-events-v0.1.json
+++ b/docs/protocol-events-v0.1.json
@@ -1,0 +1,81 @@
+[
+  {
+    "name": "node_selection_changed",
+    "description": "Fires when the active selection in a node editor changes, capturing the active node and current selection list.",
+    "origin": "bpy.app.handlers.depsgraph_update_post (listening for context selection changes in node trees)",
+    "payload_schema_example": {
+      "tree_name": "Geometry Nodes",
+      "tree_id": "GeometryNodeTree.001",
+      "selected_nodes": [
+        {"name": "Group Input", "type": "NodeGroupInput", "id": "Node.001"},
+        {"name": "Point Translate", "type": "GeometryNodeSetPosition", "id": "Node.002"}
+      ],
+      "active_node": {"name": "Point Translate", "type": "GeometryNodeSetPosition", "id": "Node.002"},
+      "timestamp": "2024-07-16T12:00:00Z"
+    }
+  },
+  {
+    "name": "node_created",
+    "description": "Raised when a new node is added to a node tree (e.g., Geometry Nodes, Shader Nodes).",
+    "origin": "bpy.app.handlers.depsgraph_update_post (monitoring new datablocks of type bpy.types.Node)",
+    "payload_schema_example": {
+      "tree_name": "Geometry Nodes",
+      "tree_id": "GeometryNodeTree.001",
+      "node": {
+        "name": "Mix", "type": "ShaderNodeMix", "id": "Node.010", "label": "Layer Mix"
+      },
+      "created_in": "Object.Data.GeometryNodes",
+      "timestamp": "2024-07-16T12:00:01Z"
+    }
+  },
+  {
+    "name": "node_parameter_changed",
+    "description": "Signals that a node property (e.g., input default value, boolean toggle) changed on the active node.",
+    "origin": "bpy.app.handlers.depsgraph_update_post or bpy.msgbus subscriptions on RNA property updates",
+    "payload_schema_example": {
+      "tree_name": "Geometry Nodes",
+      "tree_id": "GeometryNodeTree.001",
+      "node": {"name": "Attribute Statistic", "type": "GeometryNodeAttributeStatistic", "id": "Node.005"},
+      "property": "domain",
+      "old_value": "POINT",
+      "new_value": "EDGE",
+      "timestamp": "2024-07-16T12:00:05Z"
+    }
+  },
+  {
+    "name": "frame_changed",
+    "description": "Emitted after the scene frame changes to synchronize time-based updates.",
+    "origin": "bpy.app.handlers.frame_change_post",
+    "payload_schema_example": {
+      "scene": "Scene",
+      "frame_current": 42,
+      "subframe": 0.0,
+      "is_playback": true,
+      "timestamp": "2024-07-16T12:00:10Z"
+    }
+  },
+  {
+    "name": "render_completed",
+    "description": "Triggered when a render job finishes, providing the output path and render statistics.",
+    "origin": "bpy.app.handlers.render_complete",
+    "payload_schema_example": {
+      "scene": "Scene",
+      "filepath": "/tmp/render_0042.png",
+      "frame": 42,
+      "engine": "CYCLES",
+      "duration_ms": 1530,
+      "timestamp": "2024-07-16T12:01:00Z"
+    }
+  },
+  {
+    "name": "file_saved",
+    "description": "Fires after a .blend file is saved so external tools can sync assets or metadata.",
+    "origin": "bpy.app.handlers.save_post",
+    "payload_schema_example": {
+      "filepath": "/home/user/projects/scene.blend",
+      "blender_version": "4.5.4",
+      "incremental": false,
+      "timestamp": "2024-07-16T12:01:30Z"
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- add a Blender 4.5 protocol event catalog with payload schema examples
- document how to extend the catalog for future Blender versions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ff93f2a44832b86e810912b54d3ee)